### PR TITLE
Segmental QC now filters out segmental calls that are the same as whole-chromosome calls

### DIFF
--- a/analysis/segmental_calling/segmental.smk
+++ b/analysis/segmental_calling/segmental.smk
@@ -233,6 +233,7 @@ rule merge_aneuploidy_w_segmental:
             (pl.col("mean_posterior") >= params.ppThresh)
             & (pl.col("segment_size") >= params.lengthThresh)
             & (pl.col("nsnps") > params.nsnps)
+            & (pl.col("karyotype") != pl.col("bf_max_cat"))
         )
         filt_seg_df.write_csv(
             output.postqc_segmental_calls, separator="\t", null_value="NA"


### PR DESCRIPTION
This is a patch for #35 where we effectively have made sure that _any_ post-QC segmental call has the following properties: 

* >= 100 consecutive SNPs 
* >= 5 Mb in physical length
* >= 0.9 mean posterior probability across the entire segment
* The estimated karyotype (or ploidy status) of the segment) is not the `bf_max_cat` of the whole chromosome (based on the full aneuploidy estimator). 

This should mirror the filtering standards in the `natera_segmental` repository currently as well 