### PR TITLE
Use phased data for chrX aneuploidy calling

### DIFF
--- a/analysis/sex_embryo/scripts/sex_chrom_hmm.py
+++ b/analysis/sex_embryo/scripts/sex_chrom_hmm.py
@@ -87,7 +87,6 @@ def posterior_chrX_karyotype(bafs, pos, mat_haps, pat_haps, **kwargs):
         pat_haps=pat_haps,
         pi0=pi0_est,
         std_dev=sigma_est,
-        unphased=True,
     )
     res_dict = hmm.posterior_karyotypes(gammas, karyotypes)
     res_dict["pi0_est_chrX"] = pi0_est
@@ -121,6 +120,7 @@ def posterior_chrY_karyotype(bafs, pos, pat_haps, **kwargs):
         mat_haps=mat_haps,
         pat_haps=pat_haps,
         sigma_bounds=(1e-2, 0.4),
+        unphased=True,
     )
     # 2. run fwd-bwd decoding for the HMM for state probabilities
     gammas, states, karyotypes = hmm.forward_backward(

--- a/analysis/sex_embryo/sex_embryos.smk
+++ b/analysis/sex_embryo/sex_embryos.smk
@@ -29,9 +29,14 @@ lrrs = ["none"]
 # Create the VCF data dictionary for the sex-chromosomes
 vcf_dict = {}
 chroms = ["chrX", "chrY"]
+# vcf_dict["chrX"] = (
+# "/data/rmccoy22/natera_spectrum/genotypes/opticall_parents_100423/genotypes/opticall_concat_23.norm.b38.vcf.gz"
+# )
 vcf_dict["chrX"] = (
-    "/data/rmccoy22/natera_spectrum/genotypes/opticall_parents_100423/genotypes/opticall_concat_23.norm.b38.vcf.gz"
+    "/data/rmccoy22/natera_spectrum/genotypes/opticall_parents_100423/genotypes/eagle_phased_hg38/natera_parents.b38.beagle.chr23.annot.vcf.gz"
 )
+
+
 vcf_dict["chrY"] = (
     "/data/rmccoy22/natera_spectrum/genotypes/opticall_parents_100423/genotypes/opticall_concat_24.norm.b38.vcf.gz"
 )


### PR DESCRIPTION
This PR shifts the algorithm for aneuploidy calling to use population-phased chrX data when running the model for aneuploidy detection. This allows for using LD along individual haplotypes observed at the population level to avoid the naive transition model `unphased=True` in the `MetaHMM`. 

This _substantially_ improves performance (96% of entries have a greater posterior after using phased data). From the below plot it is also easy to see that there are a much higher fraction of calls that now pass the threshold of having a posterior > 90%. 

![download-8](https://github.com/user-attachments/assets/c4c81458-4e4c-49e6-8adf-418a88d2250a)
